### PR TITLE
Fix login template rendering and add basic styling

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -21,6 +21,7 @@ func main() {
 
 	app := server.New(db)
 	mux := http.NewServeMux()
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
 	mux.HandleFunc("/", app.Home)
 	mux.HandleFunc("/register", app.Register)
 	mux.HandleFunc("/login", app.Login)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"html/template"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -15,13 +16,18 @@ import (
 // App holds application dependencies.
 type App struct {
 	DB        *sql.DB
-	Templates *template.Template
+	Templates map[string]*template.Template
 }
 
 // New creates a new App instance.
 func New(db *sql.DB) *App {
-	tmpl := template.Must(template.ParseGlob("templates/*.html"))
-	return &App{DB: db, Templates: tmpl}
+	base := template.Must(template.ParseFiles("templates/base.html"))
+	files := []string{"index.html", "login.html", "register.html", "create_post.html", "post.html"}
+	templates := make(map[string]*template.Template)
+	for _, f := range files {
+		templates[f] = template.Must(template.Must(base.Clone()).ParseFiles(filepath.Join("templates", f)))
+	}
+	return &App{DB: db, Templates: templates}
 }
 
 // Helper to get current user from request.
@@ -66,14 +72,14 @@ func (a *App) Home(w http.ResponseWriter, r *http.Request) {
 		"Filter":      filter,
 		"Category":    category,
 	}
-	a.Templates.ExecuteTemplate(w, "index.html", data)
+	a.Templates["index.html"].ExecuteTemplate(w, "base", data)
 }
 
 // Register displays and handles user registration.
 func (a *App) Register(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		a.Templates.ExecuteTemplate(w, "register.html", nil)
+		a.Templates["register.html"].ExecuteTemplate(w, "base", nil)
 	case http.MethodPost:
 		email := strings.TrimSpace(r.FormValue("email"))
 		username := strings.TrimSpace(r.FormValue("username"))
@@ -96,7 +102,7 @@ func (a *App) Register(w http.ResponseWriter, r *http.Request) {
 func (a *App) Login(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		a.Templates.ExecuteTemplate(w, "login.html", nil)
+		a.Templates["login.html"].ExecuteTemplate(w, "base", nil)
 	case http.MethodPost:
 		email := r.FormValue("email")
 		password := r.FormValue("password")
@@ -142,7 +148,7 @@ func (a *App) CreatePost(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		categories, _ := models.GetCategories(a.DB)
 		data := map[string]interface{}{"Categories": categories}
-		a.Templates.ExecuteTemplate(w, "create_post.html", data)
+		a.Templates["create_post.html"].ExecuteTemplate(w, "base", data)
 	case http.MethodPost:
 		title := strings.TrimSpace(r.FormValue("title"))
 		content := strings.TrimSpace(r.FormValue("content"))
@@ -186,7 +192,7 @@ func (a *App) ViewPost(w http.ResponseWriter, r *http.Request) {
 			"Comments":    comments,
 			"CurrentUser": a.currentUser(r),
 		}
-		a.Templates.ExecuteTemplate(w, "post.html", data)
+		a.Templates["post.html"].ExecuteTemplate(w, "base", data)
 	case http.MethodPost:
 		cu := a.currentUser(r)
 		if cu == nil {

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,19 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+nav a {
+    margin-right: 10px;
+}
+
+form label {
+    display: block;
+    margin: 5px 0;
+}
+
+article {
+    margin-bottom: 20px;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8">
     <title>{{block "title" .}}Forum{{end}}</title>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <nav>


### PR DESCRIPTION
## Summary
- serve static CSS and link it in base template
- build per-page templates to prevent login from showing registration page
- map handlers to their own templates

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a09c78af04832a9b1669d39909c834